### PR TITLE
refactor: remove unneeded dynamic font scaling opt-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@capacitor/core": "^4.6.1",
         "@capacitor/preferences": "^4.0.2",
-        "@ionic/react": "^7.6.2-dev.11704998705.1e1f9850",
-        "@ionic/react-router": "^7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/react": "^7.7.2-dev.11707425083.192d8103",
+        "@ionic/react-router": "^7.7.2-dev.11707425083.192d8103",
         "date-fns": "^2.25.0",
         "ionicons": "^7.1.2",
         "react": "^18.2.0",
@@ -512,21 +512,21 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-/Vdrgyq8aFr68KaNrChuejCUGppj+IbwR1CmZm9/S0+w12mtCyVM5+6VVq9CLAVi0YG7m2AK2S5ENtK+hv4Ljw==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
       "dependencies": {
-        "@stencil/core": "^4.8.2",
-        "ionicons": "^7.2.1",
+        "@stencil/core": "^4.12.0",
+        "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/react": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-sX2BIPGAZPuiyyCkVfOQHTVS1uZrbSBYlkB4sZ8OsosFNvF7cS+lPn74lsmGvFiBEPjk93Un/o86fR2uIfvGvg==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-ySHpk3hI4XvRmIQeg9c5keP4rKkf4QKhva5AGBXwZdz0WW2lZjkxOSUT1oGDP5oPJn+YbrYk4BgKQ7r34vu+fw==",
       "dependencies": {
-        "@ionic/core": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
         "ionicons": "^7.0.0",
         "tslib": "*"
       },
@@ -536,11 +536,11 @@
       }
     },
     "node_modules/@ionic/react-router": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-06UgqqhgPUV55ekLOWvafEWjXeMXTsmQAnFoGntqTPXeWWeMd9zO4B4DD6grRozkjlpxzP/2N4nzBkP7jCVAVA==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-/3stkn9w7VadRpXUt96YuL25GSnnDjpcFRJFj78c9GBObrQK7S+fScdaRzpeJxIsb+oT9Y5mAuWyWNNJXJipfQ==",
       "dependencies": {
-        "@ionic/react": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/react": "7.7.2-dev.11707425083.192d8103",
         "tslib": "*"
       },
       "peerDependencies": {
@@ -806,9 +806,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
-      "integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
+      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -3998,31 +3998,31 @@
       }
     },
     "@ionic/core": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-/Vdrgyq8aFr68KaNrChuejCUGppj+IbwR1CmZm9/S0+w12mtCyVM5+6VVq9CLAVi0YG7m2AK2S5ENtK+hv4Ljw==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
       "requires": {
-        "@stencil/core": "^4.8.2",
-        "ionicons": "^7.2.1",
+        "@stencil/core": "^4.12.0",
+        "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
     "@ionic/react": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-sX2BIPGAZPuiyyCkVfOQHTVS1uZrbSBYlkB4sZ8OsosFNvF7cS+lPn74lsmGvFiBEPjk93Un/o86fR2uIfvGvg==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-ySHpk3hI4XvRmIQeg9c5keP4rKkf4QKhva5AGBXwZdz0WW2lZjkxOSUT1oGDP5oPJn+YbrYk4BgKQ7r34vu+fw==",
       "requires": {
-        "@ionic/core": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
         "ionicons": "^7.0.0",
         "tslib": "*"
       }
     },
     "@ionic/react-router": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-06UgqqhgPUV55ekLOWvafEWjXeMXTsmQAnFoGntqTPXeWWeMd9zO4B4DD6grRozkjlpxzP/2N4nzBkP7jCVAVA==",
+      "version": "7.7.2-dev.11707425083.192d8103",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.7.2-dev.11707425083.192d8103.tgz",
+      "integrity": "sha512-/3stkn9w7VadRpXUt96YuL25GSnnDjpcFRJFj78c9GBObrQK7S+fScdaRzpeJxIsb+oT9Y5mAuWyWNNJXJipfQ==",
       "requires": {
-        "@ionic/react": "7.6.2-dev.11704998705.1e1f9850",
+        "@ionic/react": "7.7.2-dev.11707425083.192d8103",
         "tslib": "*"
       }
     },
@@ -4235,9 +4235,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
-      "integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
+      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ=="
     },
     "@testing-library/dom": {
       "version": "6.10.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@capacitor/core": "^4.6.1",
     "@capacitor/preferences": "^4.0.2",
-    "@ionic/react": "^7.6.2-dev.11704998705.1e1f9850",
-    "@ionic/react-router": "^7.6.2-dev.11704998705.1e1f9850",
+    "@ionic/react": "^7.7.2-dev.11707425083.192d8103",
+    "@ionic/react-router": "^7.7.2-dev.11707425083.192d8103",
     "date-fns": "^2.25.0",
     "ionicons": "^7.1.2",
     "react": "^18.2.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -4,11 +4,3 @@
  * Put style rules here that you want to apply globally. These styles are for
  * the entire app and not just one component.
  */
-
-html {
-  /*
-   * For more information on dynamic font scaling, visit the documentation:
-   * https://ionicframework.com/docs/layout/dynamic-font-scaling
-   */
-  --ion-dynamic-font: var(--ion-default-dynamic-font);
-}


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-framework/pull/28966, we enabled dynamic font scaling by default. As a result, the CSS that manually opts into it is no longer needed.

The dev build contains the latest Ionic v8 work, including the aforementioned PR.