### PR TITLE
refactor(app): update path and naming for latest v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@capacitor/core": "^4.6.1",
         "@capacitor/preferences": "^4.0.2",
-        "@ionic/react": "^7.7.2-dev.11707425083.192d8103",
-        "@ionic/react-router": "^7.7.2-dev.11707425083.192d8103",
+        "@ionic/react": "^8.0.0-rc.1",
+        "@ionic/react-router": "^8.0.0-rc.1",
         "date-fns": "^2.25.0",
         "ionicons": "^7.1.2",
         "react": "^18.2.0",
@@ -512,21 +512,21 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-rc.1.tgz",
+      "integrity": "sha512-pnpzoMyKgIlySVNJVMYSL1UTFGC+RwGyKGGlEyfWxpVk+WfLSmeTc7IoTlUAmc8tygOJWZuv5nP19pYVgeisjg==",
       "dependencies": {
-        "@stencil/core": "^4.12.0",
+        "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/react": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-ySHpk3hI4XvRmIQeg9c5keP4rKkf4QKhva5AGBXwZdz0WW2lZjkxOSUT1oGDP5oPJn+YbrYk4BgKQ7r34vu+fw==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-8.0.0-rc.1.tgz",
+      "integrity": "sha512-7xg48wsDIcVGwxPFsa0rBvOepL8pI+MrKq9p7QxjQ6M6HXm7B6aAMi/zwSff9got1M86rf38uRFiZskxqN/7Mg==",
       "dependencies": {
-        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/core": "8.0.0-rc.1",
         "ionicons": "^7.0.0",
         "tslib": "*"
       },
@@ -536,11 +536,11 @@
       }
     },
     "node_modules/@ionic/react-router": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-/3stkn9w7VadRpXUt96YuL25GSnnDjpcFRJFj78c9GBObrQK7S+fScdaRzpeJxIsb+oT9Y5mAuWyWNNJXJipfQ==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-8.0.0-rc.1.tgz",
+      "integrity": "sha512-5ijZ9oMpXA+2RoZjkiu3Qn4vhXRMWLmJZWCKmm6YKBv7108UTlZMjBYtpX8RQEHf3xiUpmcSGNqPJHZkAeqrvQ==",
       "dependencies": {
-        "@ionic/react": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/react": "8.0.0-rc.1",
         "tslib": "*"
       },
       "peerDependencies": {
@@ -806,9 +806,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
-      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.15.0.tgz",
+      "integrity": "sha512-C5syM3chCyxX0Os5M+ZWrBujjqwUfrTb87YiLr8RC+kMTmIpnRvvtj8/s3QYDGdDENGRxGkBpeboVh82IGqk0w==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -3998,31 +3998,31 @@
       }
     },
     "@ionic/core": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-eU8Jw9owrswoEtePoK9EU2PipoIVY8/3hm5U1o94s9wguUGW9Jk+gtr61EgteU8ZiXcjyFMw+YsrHSAZfZJu+w==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-rc.1.tgz",
+      "integrity": "sha512-pnpzoMyKgIlySVNJVMYSL1UTFGC+RwGyKGGlEyfWxpVk+WfLSmeTc7IoTlUAmc8tygOJWZuv5nP19pYVgeisjg==",
       "requires": {
-        "@stencil/core": "^4.12.0",
+        "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
     "@ionic/react": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-ySHpk3hI4XvRmIQeg9c5keP4rKkf4QKhva5AGBXwZdz0WW2lZjkxOSUT1oGDP5oPJn+YbrYk4BgKQ7r34vu+fw==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-8.0.0-rc.1.tgz",
+      "integrity": "sha512-7xg48wsDIcVGwxPFsa0rBvOepL8pI+MrKq9p7QxjQ6M6HXm7B6aAMi/zwSff9got1M86rf38uRFiZskxqN/7Mg==",
       "requires": {
-        "@ionic/core": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/core": "8.0.0-rc.1",
         "ionicons": "^7.0.0",
         "tslib": "*"
       }
     },
     "@ionic/react-router": {
-      "version": "7.7.2-dev.11707425083.192d8103",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.7.2-dev.11707425083.192d8103.tgz",
-      "integrity": "sha512-/3stkn9w7VadRpXUt96YuL25GSnnDjpcFRJFj78c9GBObrQK7S+fScdaRzpeJxIsb+oT9Y5mAuWyWNNJXJipfQ==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-8.0.0-rc.1.tgz",
+      "integrity": "sha512-5ijZ9oMpXA+2RoZjkiu3Qn4vhXRMWLmJZWCKmm6YKBv7108UTlZMjBYtpX8RQEHf3xiUpmcSGNqPJHZkAeqrvQ==",
       "requires": {
-        "@ionic/react": "7.7.2-dev.11707425083.192d8103",
+        "@ionic/react": "8.0.0-rc.1",
         "tslib": "*"
       }
     },
@@ -4235,9 +4235,9 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.1.tgz",
-      "integrity": "sha512-l7UUCEV+4Yr1i6BL2DGSQPAzM3x/V4Fx9n9Z0/gdAgX11I25xY0MnH5jbQ69ug6ms/8KUV6SouS1R7MjjM/JnQ=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.15.0.tgz",
+      "integrity": "sha512-C5syM3chCyxX0Os5M+ZWrBujjqwUfrTb87YiLr8RC+kMTmIpnRvvtj8/s3QYDGdDENGRxGkBpeboVh82IGqk0w=="
     },
     "@testing-library/dom": {
       "version": "6.10.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@capacitor/core": "^4.6.1",
     "@capacitor/preferences": "^4.0.2",
-    "@ionic/react": "^7.7.2-dev.11707425083.192d8103",
-    "@ionic/react-router": "^7.7.2-dev.11707425083.192d8103",
+    "@ionic/react": "^8.0.0-rc.1",
+    "@ionic/react-router": "^8.0.0-rc.1",
     "date-fns": "^2.25.0",
     "ionicons": "^7.1.2",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,15 +27,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-// import "@ionic/react/css/themes/dark.always.css";
-// import "@ionic/react/css/themes/dark.system.css";
-import "@ionic/react/css/themes/dark.class.css";
+// import "@ionic/react/css/palettes/dark.always.css";
+// import "@ionic/react/css/palettes/dark.system.css";
+import "@ionic/react/css/palettes/dark.class.css";
 
 /* Theme variables */
 import './theme/variables.css';
@@ -101,7 +101,7 @@ const IonicApp: React.FC<IonicAppProps> = ({
   return schedule.groups.length === 0 ? (
     <div></div>
   ) : (
-    <IonApp className={`${darkMode ? 'ion-theme-dark' : ''}`}>
+    <IonApp className={`${darkMode ? 'ion-palette-dark' : ''}`}>
       <IonReactRouter>
         <IonSplitPane contentId="main">
           <Menu />


### PR DESCRIPTION
Updates the following for v8:

- Uses the latest version of `@ionic/react@next` and `@ionic/react-router@next`
- Renames `css/themes` to `css/palettes` for dark mode imports
- Updates `ion-theme-dark` to `ion-palette-dark`