### PR TITLE
chore: update ionicons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/leaflet": "^1.9.17",
         "@types/react-redux": "^7.1.34",
         "date-fns": "^2.25.0",
-        "ionicons": "^7.1.2",
+        "ionicons": "7.4.1-dev.11746148895.17a2f833",
         "leaflet": "^1.9.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -898,6 +898,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@ionic/core/node_modules/ionicons": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.0.tgz",
+      "integrity": "sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stencil/core": "^4.0.3"
+      }
+    },
     "node_modules/@ionic/react": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/@ionic/react/-/react-8.5.0.tgz",
@@ -926,6 +935,15 @@
         "react-dom": ">=16.8.6",
         "react-router": "^5.0.1",
         "react-router-dom": "^5.0.1"
+      }
+    },
+    "node_modules/@ionic/react/node_modules/ionicons": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.0.tgz",
+      "integrity": "sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stencil/core": "^4.0.3"
       }
     },
     "node_modules/@ionic/utils-array": {
@@ -1589,7 +1607,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1603,7 +1620,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1673,7 +1689,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,7 +1702,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1757,7 +1771,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,7 +1784,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1785,7 +1797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,7 +1824,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3165,12 +3175,35 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.0.tgz",
-      "integrity": "sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==",
+      "version": "7.4.1-dev.11746148895.17a2f833",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.4.1-dev.11746148895.17a2f833.tgz",
+      "integrity": "sha512-AoNNQ5I0z61Q7CKSvPRweBVu9JUt1O2p0Y5ueGYgvTOkioNjxBJcQiMMiXgj8iP7UufBlInLU6f43LYbiM6A6Q==",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.0.3"
+        "@stencil/core": "^4.30.0"
+      }
+    },
+    "node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.30.0.tgz",
+      "integrity": "sha512-rInn2BaN3ISgtz+yfOeiTvAvY+xjz8g5v9hDtQMIP6uefjO6JHXGhUJw2CujnuEOWjYeVR/BYdZJTi0dWN9/vQ==",
+      "license": "MIT",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "4.34.9",
+        "@rollup/rollup-darwin-x64": "4.34.9",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+        "@rollup/rollup-linux-arm64-musl": "4.34.9",
+        "@rollup/rollup-linux-x64-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-musl": "4.34.9",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+        "@rollup/rollup-win32-x64-msvc": "4.34.9"
       }
     },
     "node_modules/is-docker": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/leaflet": "^1.9.17",
     "@types/react-redux": "^7.1.34",
     "date-fns": "^2.25.0",
-    "ionicons": "^7.1.2",
+    "ionicons": "7.4.1-dev.11746148895.17a2f833",
     "leaflet": "^1.9.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
This patch updates Ionicon to the new dev build to verify if everything renders correctly. Since the app uses `IonIcon` and passes the svg as raw string, we don't render the icons through the Ionicon component. That said, we basically can confirm here that importing the raw SVG strings from `ionicons/icons` still works.

To test, checkout this branch and run:

```sh
npm install
npm start
```